### PR TITLE
Add pyecharts

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [ipywidgets](https://github.com/jupyter-widgets/ipywidgets) - UI widgets for Jupyter.
 - [jupyterlab_voyager](https://github.com/altair-viz/jupyterlab_voyager) - Extension to view CSV and JSON data in [Voyager](http://vega.github.io/voyager/).
 - [mpld3](http://mpld3.github.io) - Combining Matplotlib and D3js vor interactive data visualizations.
-- [pyecharts](https://github.com/pyecharts/pyecharts) - Bridge an interactive visualization library, [Echarts.js](https://github.com/apache/incubator-echarts) for data scientists and web developers.
+- [pyecharts](https://github.com/pyecharts/pyecharts) - Python interface for the [ECharts](https://github.com/apache/incubator-echarts) visualization library.
 - [pythreejs](https://github.com/jovyan/pythreejs) - Python / ThreeJS bridge utilizing the Jupyter widget infrastructure.
 - [Qgrid](https://github.com/quantopian/qgrid) - Interactive grid for sorting, filtering, and editing DataFrames in Jupyter notebooks.
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [ipywidgets](https://github.com/jupyter-widgets/ipywidgets) - UI widgets for Jupyter.
 - [jupyterlab_voyager](https://github.com/altair-viz/jupyterlab_voyager) - Extension to view CSV and JSON data in [Voyager](http://vega.github.io/voyager/).
 - [mpld3](http://mpld3.github.io) - Combining Matplotlib and D3js vor interactive data visualizations.
+- [pyecharts](https://github.com/pyecharts/pyecharts) - Bridge an interactive visualization library, [Echarts.js](https://github.com/apache/incubator-echarts) for data scientists and web developers.
 - [pythreejs](https://github.com/jovyan/pythreejs) - Python / ThreeJS bridge utilizing the Jupyter widget infrastructure.
 - [Qgrid](https://github.com/quantopian/qgrid) - Interactive grid for sorting, filtering, and editing DataFrames in Jupyter notebooks.
 


### PR DESCRIPTION
Hello, Markus

I came across your nice awesome list for jupyter this week and I hoped that I could add [pyecharts](https://github.com/pyecharts/pyecharts), as I am one of the contributors. 

Pyecharts supports [28+ charts ranging from 2D, 3D and geo mapping](http://nbviewer.jupyter.org/github/pyecharts/pyecharts-users-cases/blob/master/notebook-users-cases/notebook-user-cases.ipynb). It supports data scientists using Jupyter, nteract and supports web developers with django and flask integration. It will be my and the team's pleasure that someone may find it useful.

Thanks 