### PR TITLE
Add `ipyleaflet` to the visualisation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [pyecharts](https://github.com/pyecharts/pyecharts) - Python interface for the [ECharts](https://github.com/apache/incubator-echarts) visualization library.
 - [pythreejs](https://github.com/jovyan/pythreejs) - Python / ThreeJS bridge utilizing the Jupyter widget infrastructure.
 - [Qgrid](https://github.com/quantopian/qgrid) - Interactive grid for sorting, filtering, and editing DataFrames in Jupyter notebooks.
+- [ipyleaflet](https://github.com/jupyter-widgets/ipyleaflet) - Interactive visualization library for Leaflet.js maps.
 
 ## Rendering/Publishing/Conversion
 

--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [Bokeh](https://bokeh.pydata.org/en/latest/) - Interactive visualization library that targets modern web browsers for presentation.
 - [bqplot](https://github.com/bloomberg/bqplot) - Grammar of Graphics-based interactive plotting framework for Jupyter.
 - [IPySigma](https://github.com/bsnacks000/IPySigma-Demo) - Prototype network visualization frontend for Jupyter notebooks.
+- [ipyleaflet](https://github.com/jupyter-widgets/ipyleaflet) - Interactive visualization library for Leaflet.js maps in Jupyter noteboks.
 - [ipywidgets](https://github.com/jupyter-widgets/ipywidgets) - UI widgets for Jupyter.
 - [mpld3](http://mpld3.github.io) - Combining Matplotlib and D3js vor interactive data visualizations.
 - [pyecharts](https://github.com/pyecharts/pyecharts) - Python interface for the [ECharts](https://github.com/apache/incubator-echarts) visualization library.
 - [pythreejs](https://github.com/jovyan/pythreejs) - Python / ThreeJS bridge utilizing the Jupyter widget infrastructure.
 - [Qgrid](https://github.com/quantopian/qgrid) - Interactive grid for sorting, filtering, and editing DataFrames in Jupyter notebooks.
-- [ipyleaflet](https://github.com/jupyter-widgets/ipyleaflet) - Interactive visualization library for Leaflet.js maps in Jupyter noteboks.
 
 ## Rendering/Publishing/Conversion
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [pyecharts](https://github.com/pyecharts/pyecharts) - Python interface for the [ECharts](https://github.com/apache/incubator-echarts) visualization library.
 - [pythreejs](https://github.com/jovyan/pythreejs) - Python / ThreeJS bridge utilizing the Jupyter widget infrastructure.
 - [Qgrid](https://github.com/quantopian/qgrid) - Interactive grid for sorting, filtering, and editing DataFrames in Jupyter notebooks.
-- [ipyleaflet](https://github.com/jupyter-widgets/ipyleaflet) - Interactive visualization library for Leaflet.js maps.
+- [ipyleaflet](https://github.com/jupyter-widgets/ipyleaflet) - Interactive visualization library for Leaflet.js maps in Jupyter noteboks.
 
 ## Rendering/Publishing/Conversion
 


### PR DESCRIPTION
[ipyleaflet](https://github.com/jupyter-widgets/ipyleaflet) is a library for building interactive visualisations with Leaflet.js maps in notebooks using the Jupyter widgets framework.

It is 
- a mature project (the first commit by Brian Granger dates back to 2015)
- actively maintained by Jupyter widget maintainers (primarily @SylvainCorlay) 
- has a strong user base (it has just shy of 50,000 downloads on [conda-forge](https://anaconda.org/conda-forge/ipyleaflet)).