### PR TITLE
Add `jupyter-gmaps` to visualisation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [pyecharts](https://github.com/pyecharts/pyecharts) - Python interface for the [ECharts](https://github.com/apache/incubator-echarts) visualization library.
 - [pythreejs](https://github.com/jovyan/pythreejs) - Python / ThreeJS bridge utilizing the Jupyter widget infrastructure.
 - [Qgrid](https://github.com/quantopian/qgrid) - Interactive grid for sorting, filtering, and editing DataFrames in Jupyter notebooks.
+- [jupyter-gmaps](https://github.com/pbugnion/gmaps) - Interactive visualization library for Google Maps in Jupyter notebooks.
 
 ## Rendering/Publishing/Conversion
 

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [bqplot](https://github.com/bloomberg/bqplot) - Grammar of Graphics-based interactive plotting framework for Jupyter.
 - [IPySigma](https://github.com/bsnacks000/IPySigma-Demo) - Prototype network visualization frontend for Jupyter notebooks.
 - [ipywidgets](https://github.com/jupyter-widgets/ipywidgets) - UI widgets for Jupyter.
+- [jupyter-gmaps](https://github.com/pbugnion/gmaps) - Interactive visualization library for Google Maps in Jupyter notebooks.
 - [mpld3](http://mpld3.github.io) - Combining Matplotlib and D3js vor interactive data visualizations.
 - [pyecharts](https://github.com/pyecharts/pyecharts) - Python interface for the [ECharts](https://github.com/apache/incubator-echarts) visualization library.
 - [pythreejs](https://github.com/jovyan/pythreejs) - Python / ThreeJS bridge utilizing the Jupyter widget infrastructure.
 - [Qgrid](https://github.com/quantopian/qgrid) - Interactive grid for sorting, filtering, and editing DataFrames in Jupyter notebooks.
-- [jupyter-gmaps](https://github.com/pbugnion/gmaps) - Interactive visualization library for Google Maps in Jupyter notebooks.
 
 ## Rendering/Publishing/Conversion
 


### PR DESCRIPTION
[jupyter-gmaps](https://github.com/pbugnion/gmaps) is a library for building interactive visualisations with Google maps in notebooks using the Jupyter widgets framework.

It is 
- a mature project (the first commit dates back to 2015)
- actively maintained by Jupyter widget maintainers (primarily myself) and members of the community (there are 13 existing contributors).
- has a strong user base (it has 27,000 downloads on [conda-forge](https://anaconda.org/conda-forge/ipyleaflet)) and 407 stars on GitHub.