### PR TITLE
Add jupyterlab-go-to-definition extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [celltags](https://github.com/jupyterlab/jupyterlab-celltags) - Extension to organise and execute notebooks using cell tags.
 - [drawio](https://github.com/QuantStack/jupyterlab-drawio) - Extension that displays drawio/mxgraph diagrams.
 - [git](https://github.com/jupyterlab/jupyterlab-git) - Extension for git integration.
+- [go-to-definition](https://github.com/krassowski/jupyterlab-go-to-definition) - Extension for jumping to the definition of variables and functions in JupyterLab.
 - [google-drive](https://github.com/jupyterlab/jupyterlab-google-drive) - Extension for Google Drive integration.
 - [latex](https://github.com/jupyterlab/jupyterlab-latex) - Extension for live editing of LaTeX documents.
 - [statusbar](https://github.com/jupyterlab/jupyterlab-statusbar) - Statusbar that displays various metrics/states of JupyterLab.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [celltags](https://github.com/jupyterlab/jupyterlab-celltags) - Extension to organise and execute notebooks using cell tags.
 - [drawio](https://github.com/QuantStack/jupyterlab-drawio) - Extension that displays drawio/mxgraph diagrams.
 - [git](https://github.com/jupyterlab/jupyterlab-git) - Extension for git integration.
-- [go-to-definition](https://github.com/krassowski/jupyterlab-go-to-definition) - Extension for jumping to the definition of variables and functions in JupyterLab.
+- [go-to-definition](https://github.com/krassowski/jupyterlab-go-to-definition) - Extension for navigating to the definition of a variable or function in JupyterLab.
 - [google-drive](https://github.com/jupyterlab/jupyterlab-google-drive) - Extension for Google Drive integration.
 - [latex](https://github.com/jupyterlab/jupyterlab-latex) - Extension for live editing of LaTeX documents.
 - [statusbar](https://github.com/jupyterlab/jupyterlab-statusbar) - Statusbar that displays various metrics/states of JupyterLab.


### PR DESCRIPTION
[jupyterlab-go-to-definition](https://github.com/krassowski/jupyterlab-go-to-definition) extension allows to jump to the definition of a variable with your mouse (using <kbd>Alt</kbd> + <kbd>click</kbd>), or keyboard (with <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>B</kbd> shortcut):

![Go to definition](https://raw.githubusercontent.com/krassowski/jupyterlab-go-to-definition/master/examples/demo.gif)


The second version with support for both Python and R kernels was [warmly welcomed](https://twitter.com/krassowski_m/status/1080890436577906690) by the community.