### PR TITLE
Added Jupytext

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 
 - [Binder](http://mybinder.org) - Turn a GitHub repo into a collection of interactive notebooks.
 - [Bookbook](https://github.com/takluyver/bookbook) - Bookbook converts a set of notebooks in a directory to HTML or PDF, preserving cross references within and between notebooks.
+- [Jupytext](https://github.com/mwouts/jupytext) - Edit, refactor and version control Jupyter Notebooks represented as scripts or Markdown documents.
 - [nbconvert](https://nbconvert.readthedocs.io) - Convert Notebooks to other formats.
 - [nbdime](https://github.com/jupyter/nbdime) - Tools for diffing and merging of Jupyter notebooks.
 - [nbinteract](https://www.nbinteract.com) - Create interactive webpages from Jupyter notebooks.


### PR DESCRIPTION
Jupytext (https://github.com/mwouts/jupytext) implements a two-way conversion between Jupyter notebooks and various text formats. 

Jupytext is available as a command line tool, and as a plugin for either Jupyter Notebook or Jupyter Lab, cf. the [documentation](https://github.com/mwouts/jupytext/blob/master/README.md)