### PR TITLE
Add language-server-protocol lab extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [jupyterlab_email](https://github.com/timkpaine/jupyterlab_email) - Email notebooks and their content from within JupyterLab.
 - [jupyterlab-kyso](https://github.com/kyso-io/jupyterlab-extension) - Extension to publish notebooks to the [Kyso](https://kyso.io) platform from Jupyterlab.
 - [latex](https://github.com/jupyterlab/jupyterlab-latex) - Extension for live editing of LaTeX documents.
+- [lsp](https://github.com/krassowski/jupyterlab-lsp) - IDE superpowers (code navigation, hover suggestions, linters/diagnostics, kernel-less autocompletion, rename)
 - [nb_black](https://github.com/dnanhkhoa/nb_black) - Extension to keep Python code automatically formatted using [black](https://github.com/psf/black).
 - [python-bytecode](https://github.com/jtpio/jupyterlab-python-bytecode) - Explore CPython Bytecode in JupyterLab.
 - [quickopen](https://github.com/parente/jupyterlab-quickopen) - Quickly open a file in JupyterLab by typing part of its name.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [jupyterlab_email](https://github.com/timkpaine/jupyterlab_email) - Email notebooks and their content from within JupyterLab.
 - [jupyterlab-kyso](https://github.com/kyso-io/jupyterlab-extension) - Extension to publish notebooks to the [Kyso](https://kyso.io) platform from Jupyterlab.
 - [latex](https://github.com/jupyterlab/jupyterlab-latex) - Extension for live editing of LaTeX documents.
-- [lsp](https://github.com/krassowski/jupyterlab-lsp) - IDE superpowers (code navigation, hover suggestions, linters/diagnostics, kernel-less autocompletion, rename)
+- [lsp](https://github.com/krassowski/jupyterlab-lsp) - IDE-like features (code navigation, hover suggestions, linters, diagnostics, kernel-less autocompletion etc.)
 - [nb_black](https://github.com/dnanhkhoa/nb_black) - Extension to keep Python code automatically formatted using [black](https://github.com/psf/black).
 - [python-bytecode](https://github.com/jtpio/jupyterlab-python-bytecode) - Explore CPython Bytecode in JupyterLab.
 - [quickopen](https://github.com/parente/jupyterlab-quickopen) - Quickly open a file in JupyterLab by typing part of its name.


### PR DESCRIPTION
[jupyterlab-lsp](https://github.com/krassowski/jupyterlab-lsp) brings IDE superpowers (similar to, and using the same protocol VS Code) to JupyterLab.

Scope: jupyterlab-lsp includes code navigation (jump-to-definition), on-hover code tooltips, signature suggestions, linters (diagnostics), kernel-less autocompletion (including auto invocation on dot), and code-aware rename feature. More refactoring features are to be added.

Please feel free to shorten, or modify the description and/or title.