### PR TITLE
Update to include IllumiDesk

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 ## Collaboration/Education
 
 - [callgraph](https://github.com/osteele/callgraph) - Magic to display a function call graph.
-- [IllumiDesk](https://github.com/IllumiDesk/illumidesk) - JupyterHub + LTI + nbgrader distribution with docker containers
+- [IllumiDesk](https://github.com/IllumiDesk/illumidesk) - Docker-based JupyterHub + LTI + nbgrader distribution for teaching.
 - [IPythonBlocks](https://github.com/jiffyclub/ipythonblocks) - Practice Python with colored grids in Jupyter.
 - [jupyter-drive](https://github.com/jupyter/jupyter-drive) - Google drive for Jupyter.
 - [jupyter-viewer-xblock](https://github.com/ibleducation/jupyter-viewer-xblock) - Fetch and display part of, or an entire Jupyter Notebook in an Open edX XBlock.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 ## Collaboration/Education
 
 - [callgraph](https://github.com/osteele/callgraph) - Magic to display a function call graph.
-- [IllumiDesk](https://github.com/IllumiDesk/illumidesk) - Docker-based JupyterHub + LTI + nbgrader distribution for teaching.
+- [IllumiDesk](https://github.com/IllumiDesk/illumidesk) - Docker-based JupyterHub + LTI + nbgrader distribution for education.
 - [IPythonBlocks](https://github.com/jiffyclub/ipythonblocks) - Practice Python with colored grids in Jupyter.
 - [jupyter-drive](https://github.com/jupyter/jupyter-drive) - Google drive for Jupyter.
 - [jupyter-viewer-xblock](https://github.com/ibleducation/jupyter-viewer-xblock) - Fetch and display part of, or an entire Jupyter Notebook in an Open edX XBlock.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 ## Collaboration/Education
 
 - [callgraph](https://github.com/osteele/callgraph) - Magic to display a function call graph.
+- [IllumiDesk](https://github.com/IllumiDesk/illumidesk) - JupyterHub + LTI + nbgrader distribution with docker containers
 - [IPythonBlocks](https://github.com/jiffyclub/ipythonblocks) - Practice Python with colored grids in Jupyter.
 - [jupyter-drive](https://github.com/jupyter/jupyter-drive) - Google drive for Jupyter.
 - [jupyter-viewer-xblock](https://github.com/ibleducation/jupyter-viewer-xblock) - Fetch and display part of, or an entire Jupyter Notebook in an Open edX XBlock.


### PR DESCRIPTION
Adds IllumiDesk to the education section. Open source repo [is located here](https://github.com/IllumiDesk/illumidesk).