### PR TITLE
Propose manim visualisation engine integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [ipyvolume](https://github.com/maartenbreddels/ipyvolume) - 3D plotting for Python in Jupyter based on widgets and WebGL.
 - [itk-jupyter-widgets](https://github.com/InsightSoftwareConsortium/itk-jupyter-widgets) - Interactive widgets to visualize images in 2D and 3D.
 - [jp_doodle](https://github.com/AaronWatters/jp_doodle) - Infrastructure for building special purpose interactive diagrams in 2D and 3D.
-- [jupyter-manim](https://github.com/krassowski/jupyter-manim) - Display Mathematical Animation Engine ([manim](https://github.com/3b1b/manim)) videos or gifs in Jupyter notebooks.
+- [jupyter-manim](https://github.com/krassowski/jupyter-manim) - Display [manim](https://github.com/3b1b/manim) (Mathematical Animation Engine) videos or GIFs in Jupyter notebooks.
 - [jupyter-gmaps](https://github.com/pbugnion/gmaps) - Interactive visualization library for Google Maps in Jupyter notebooks.
 - [mpld3](http://mpld3.github.io) - Combining Matplotlib and D3js vor interactive data visualizations.
 - [pd-replicator](https://github.com/scwilkinson/pd-replicator) - Copy a pandas DataFrame to the clipboard with one click.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [ipyvolume](https://github.com/maartenbreddels/ipyvolume) - 3D plotting for Python in Jupyter based on widgets and WebGL.
 - [itk-jupyter-widgets](https://github.com/InsightSoftwareConsortium/itk-jupyter-widgets) - Interactive widgets to visualize images in 2D and 3D.
 - [jp_doodle](https://github.com/AaronWatters/jp_doodle) - Infrastructure for building special purpose interactive diagrams in 2D and 3D.
+- [jupyter-manim](https://github.com/krassowski/jupyter-manim) - Display Mathematical Animation Engine ([manim](https://github.com/3b1b/manim)) videos or gifs in Jupyter notebooks.
 - [jupyter-gmaps](https://github.com/pbugnion/gmaps) - Interactive visualization library for Google Maps in Jupyter notebooks.
 - [mpld3](http://mpld3.github.io) - Combining Matplotlib and D3js vor interactive data visualizations.
 - [pd-replicator](https://github.com/scwilkinson/pd-replicator) - Copy a pandas DataFrame to the clipboard with one click.


### PR DESCRIPTION
[jupyter-manim](https://github.com/krassowski/jupyter-manim) is an extension which allows generation and display of [manim](https://github.com/3b1b/manim) videos straight from the notebook. The added value is in the interfacing and encoding/embedding.

Notes:
- not sure if it makes the cut for "awesome" list, but it seems to be enjoyed by the users. Also, I thought it would be nice to have all the visualisation extensions in one place.
- not sure if the convention of removing `jupyter-` prefix still stands (older entries do not have it), but as to distinguish the interface (jupyter-manim) from the tool itself (manim), I kept it.