### PR TITLE
Add treebeard to testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [sphinxcontrib-jupyter](https://github.com/QuantEcon/sphinxcontrib-jupyter) - Sphinx Extension for Generating Jupyter Notebooks.
 - [nosebook](https://github.com/bollwyvl/nosebook) - Nose plugin for finding and running IPython notebooks as nose tests.
 - [treon](https://github.com/ReviewNB/treon) - Easy-to-use test framework for Jupyter Notebooks.
+- [treebeard](https://github.com/treebeardtech/treebeard) - GitHub Action for testing/scheduling Jupyter Notebooks
 
 ## Domain-Specific Projects
 

--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [nbval](https://github.com/computationalmodelling/nbval) - Py.test plugin for validating Jupyter notebooks.
 - [sphinxcontrib-jupyter](https://github.com/QuantEcon/sphinxcontrib-jupyter) - Sphinx Extension for Generating Jupyter Notebooks.
 - [nosebook](https://github.com/bollwyvl/nosebook) - Nose plugin for finding and running IPython notebooks as nose tests.
+- [treebeard](https://github.com/treebeardtech/treebeard) - GitHub Action for testing/scheduling Jupyter notebooks.
 - [treon](https://github.com/ReviewNB/treon) - Easy-to-use test framework for Jupyter Notebooks.
-- [treebeard](https://github.com/treebeardtech/treebeard) - GitHub Action for testing/scheduling Jupyter Notebooks
 
 ## Domain-Specific Projects
 


### PR DESCRIPTION
GitHub Action for testing/scheduling Jupyter Notebooks

(It could also potentially go under Rendering/Publishing/Conversion as it is built on papermill which is listed there)