### PR TITLE
Add Jupylet

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [lolviz](https://github.com/parrt/lolviz) - Data-structure visualization tool for lists of lists, lists, dictionaries.
 - [Quantopian Notebooks](https://www.quantopian.com/notebooks/survey) - Jupyter-based platform for financial research.
 - [vpython-jupyter](https://github.com/BruceSherwood/vpython-jupyter) - VPython 3D engine running in a Jupyter notebook.
+- [Jupylet](https://github.com/nir/jupylet) - Create 2D and 3D games, graphics, live music and sound synthesizers, interactively in a Jupyter notebook.
 
 ## Hosted Notebook Solutions
 

--- a/README.md
+++ b/README.md
@@ -155,10 +155,10 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [ArcGIS](https://developers.arcgis.com/python/) - Library for working with maps and geospatial data, powered by web GIS.
 - [GenePattern Notebook](http://genepattern-notebook.org) - Integrating Genomic Analysis with Interactive Notebooks.
 - [GeoNotebook](https://github.com/OpenGeoscience/geonotebook) - Extension for exploratory geospatial analysis.
+- [Jupylet](https://github.com/nir/jupylet) - Create 2D and 3D games, graphics, live music and sound interactively in a Jupyter notebook.
 - [lolviz](https://github.com/parrt/lolviz) - Data-structure visualization tool for lists of lists, lists, dictionaries.
 - [Quantopian Notebooks](https://www.quantopian.com/notebooks/survey) - Jupyter-based platform for financial research.
 - [vpython-jupyter](https://github.com/BruceSherwood/vpython-jupyter) - VPython 3D engine running in a Jupyter notebook.
-- [Jupylet](https://github.com/nir/jupylet) - Create 2D and 3D games, graphics, live music and sound synthesizers, interactively in a Jupyter notebook.
 
 ## Hosted Notebook Solutions
 


### PR DESCRIPTION
I added Jupylet to the Domain-Specific Projects section.

Jupylet is a library for creating 2d and 3d games, graphics, music and sound synthesizers interactively in a Jupyter notebook.

It was designed with three target audiences in mind:

- education: for kids learning to program.
- research: for creating controlling and rendering game environments for Deep Reinforcement Learning.
- sound: live music coding directly in a jupyter notebook.

And it has extensive documentation:
https://jupylet.readthedocs.io/en/latest/