### PR TITLE
Add Elyra extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [code_formatter](https://github.com/ryantam626/jupyterlab_code_formatter) - A universal code formatter.
 - [debugger](https://github.com/jupyterlab/debugger) - A visual debugger for Jupyter notebooks, consoles, and source files.
 - [drawio](https://github.com/QuantStack/jupyterlab-drawio) - Extension that displays drawio/mxgraph diagrams.
+- [elyra](https://github.com/elyra-ai/elyra) - A visual editor for creating and running notebook (or Python script) pipelines locally or remotely.
 - [go-to-definition](https://github.com/krassowski/jupyterlab-go-to-definition) - Extension for navigating to the definition of a variable or function in JupyterLab.
 - [google-drive](https://github.com/jupyterlab/jupyterlab-google-drive) - Extension for Google Drive integration.
 - [jupyterlab_email](https://github.com/timkpaine/jupyterlab_email) - Email notebooks and their content from within JupyterLab.


### PR DESCRIPTION
This PR adds the Elyra extension (https://github.com/elyra-ai/elyra), which (among other things) provides a visual pipeline editor for building and running notebook (or Python script) pipelines locally (aka in JupyterLab) or remotely (e.g. using Kubeflow Pipelines).