### PR TITLE
Add Ganimede

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [RISE](https://github.com/damianavila/RISE) - Reveal.js Jupyter/IPython Slideshow.
 - [rst2ipynb](https://github.com/nthiery/rst-to-ipynb) - Convert standalone reStructuredText files to Jupyter notebook file.
 - [Voila](https://github.com/QuantStack/voila) - Rendering of live Jupyter Notebooks with interactive widgets, allowing dashboarding based on Jupyter Notebooks
+- [Ganimede](https://github.com/manugraj/ganimede) - Store,Version, Edit, Update, Execute Jupyter notebooks in sandboxes and integrate directly into product via ReST interfaces.
 
 ## Version Control
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [Binder](http://mybinder.org) - Turn a GitHub repo into a collection of interactive notebooks.
 - [Bookbook](https://github.com/takluyver/bookbook) - Bookbook converts a set of notebooks in a directory to HTML or PDF, preserving cross references within and between notebooks.
 - [ContainDS Dashboards](https://github.com/ideonate/cdsdashboards) - JupyterHub extension to host authenticated scripts or notebooks in any framework (Voilà, Streamlit, Plotly Dash etc).
+- [Ganimede](https://github.com/manugraj/ganimede) - Store, version, edit and execute notebooks in sandboxes and integrate them directly via REST interfaces.
 - [Jupyter Book](https://github.com/executablebooks/jupyter-book) - Build publication-quality books and documents from computational material.
 - [Jupytext](https://github.com/mwouts/jupytext) - Convert and synchronize notebooks with text formats (e.g. Python or Markdown files) that work well under version control.
 - [jut](https://github.com/kracekumar/jut) - CLI to nicely display notebooks in the terminal.
@@ -110,8 +111,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [pynb](https://github.com/minodes/pynb) - Jupyter Notebooks as plain Python code with embedded Markdown text.
 - [RISE](https://github.com/damianavila/RISE) - Reveal.js Jupyter/IPython Slideshow.
 - [rst2ipynb](https://github.com/nthiery/rst-to-ipynb) - Convert standalone reStructuredText files to Jupyter notebook file.
-- [Voila](https://github.com/QuantStack/voila) - Rendering of live Jupyter Notebooks with interactive widgets, allowing dashboarding based on Jupyter Notebooks
-- [Ganimede](https://github.com/manugraj/ganimede) - Store,Version, Edit, Update, Execute Jupyter notebooks in sandboxes and integrate directly into product via ReST interfaces.
+- [Voila](https://github.com/QuantStack/voila) - Rendering of live Jupyter Notebooks with interactive widgets, allowing dashboarding based on Jupyter Notebooks.
 
 ## Version Control
 


### PR DESCRIPTION
Ganimede is a tool to manage jupyter notebook as a direct coded interface. We can deploy a jupyter notebook, along with a project definition. We can test and update the jupyter in a sandbox environment. We can upgrade to next version of notebook by upgrading from an edited version. It solves the pain of versioning jupyter notebook and its changes as well as it makes it easy to directly integrate it to other systems of product as a microservice.