### PR TITLE
Add databooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 
 ## Version Control
 
+- [databooks](https://github.com/datarootsio/databooks) -A command-line utility that eases versioning and sharing of notebooks. 
 - [git](https://github.com/jupyterlab/jupyterlab-git) - Extension for git integration.
 - [jupyter-nbrequirements](https://github.com/thoth-station/jupyter-nbrequirements/) - Dependency management and optimization in Jupyter Notebooks.
 - [nbdime](https://github.com/jupyter/nbdime) - Tools for diffing and merging of Jupyter notebooks.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 
 ## Version Control
 
-- [databooks](https://github.com/datarootsio/databooks) -A command-line utility that eases versioning and sharing of notebooks. 
+- [databooks](https://github.com/datarootsio/databooks) - A command-line utility that eases versioning and sharing of notebooks. 
 - [git](https://github.com/jupyterlab/jupyterlab-git) - Extension for git integration.
 - [jupyter-nbrequirements](https://github.com/thoth-station/jupyter-nbrequirements/) - Dependency management and optimization in Jupyter Notebooks.
 - [nbdime](https://github.com/jupyter/nbdime) - Tools for diffing and merging of Jupyter notebooks.


### PR DESCRIPTION
`databooks` is a package to ease the collaboration between data scientists that use Jupyter, by reducing the number of git conflicts between different notebooks and resolution of git conflicts when encountered.

The key features, as listed in the docs, include:
- CLI tool
  - Clear notebook metadata
  - Resolve git conflicts
- Simple to use
- Simple API for using modelling and comparing notebooks using [Pydantic](https://pydantic-docs.helpmanual.io/)