### PR TITLE
Add qBraid to Hosted Nb Solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [Paperspace Gradient](https://gradient.run/) - A Jupyter-backed data science IDE with accelerated hardware (GPUs) and MLOps functionality.
 - [PAWS](https://wikitech.wikimedia.org/wiki/PAWS) - Jupyter notebook deployment customized for interacting with Wikimedia wikis.
 - [Pinggy](https://pinggy.io) - Create a tunnel to your Jupyter instance even if it is behind a firewall or NAT.
+- [qBraid Lab](https://docs.qbraid.com/en/latest/lab/getting_started.html) - JupyterLab deployment providing curated software tools and integrations for researchers and developers in quantum computing.
 - [Saturn Cloud](https://saturncloud.io/) - Move your data science team into the cloud without having to switch tools.
 
 ## Official Resources and Documentation

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [Paperspace Gradient](https://gradient.run/) - A Jupyter-backed data science IDE with accelerated hardware (GPUs) and MLOps functionality.
 - [PAWS](https://wikitech.wikimedia.org/wiki/PAWS) - Jupyter notebook deployment customized for interacting with Wikimedia wikis.
 - [Pinggy](https://pinggy.io) - Create a tunnel to your Jupyter instance even if it is behind a firewall or NAT.
-- [qBraid Lab](https://docs.qbraid.com/en/latest/lab/getting_started.html) - JupyterLab deployment providing curated software tools and integrations for researchers and developers in quantum computing.
+- [qBraid Lab](https://docs.qbraid.com/en/latest/lab/getting_started.html) - JupyterLab deployment providing curated software tools and integrations for quantum computing.
 - [Saturn Cloud](https://saturncloud.io/) - Move your data science team into the cloud without having to switch tools.
 
 ## Official Resources and Documentation


### PR DESCRIPTION
Linked to docs page instead of external site (https://qbraid.com or https://lab.qbraid.com) as suggested in `CONTRIBUTING.md`. The Docker image used to build qBraid Lab must remain private, but some of the individual custom extensions may be released as open-source in the coming months. Can update if/when that occurs. Let me know if there is anything else you need!