### PR TITLE
Add Amphi for Jupyterlab extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 
 ## JupyterLab Extensions
 
+- [amphi-etl](https://github.com/amphi-ai/amphi-etl) - Low-code ETL extension for Jupyterlab.
 - [celltags](https://github.com/jupyterlab/jupyterlab-celltags) - Extension to organise and execute notebooks using cell tags.
 - [code_formatter](https://github.com/ryantam626/jupyterlab_code_formatter) - A universal code formatter.
 - [debugger](https://github.com/jupyterlab/debugger) - A visual debugger for Jupyter notebooks, consoles, and source files.


### PR DESCRIPTION
Hi, suggesting to add amphi-etl which is a Jupyterlab distribution providing a low-code ETL tool. Also available as a Jupyterlab extension.
https://github.com/amphi-ai/amphi-etl