### PR TITLE
Add Helium MCP to Domain-Specific Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [keplergl](https://docs.kepler.gl/docs/keplergl-jupyter) - Jupyter extension for visual exploration of large-scale geolocation data sets.
 - [lolviz](https://github.com/parrt/lolviz) - Data-structure visualization tool for lists of lists, lists, dictionaries.
 - [Quantopian Notebooks](https://www.quantopian.com/notebooks/survey) - Jupyter-based platform for financial research.
+- [Helium MCP](https://github.com/connerlambden/helium-mcp) - Free REST + MCP API for financial and news research from inside notebooks. Returns JSON for ML options pricing (per-symbol fair value, prob_ITM, Greeks) and 3.2M+ articles with 31-dimension bias scoring. 50 free queries per IP, no signup.
 - [vpython-jupyter](https://github.com/BruceSherwood/vpython-jupyter) - VPython 3D engine running in a Jupyter notebook.
 - [xontrib-jupyter](https://github.com/xonsh/xontrib-jupyter) - Jupyter kernel for xonsh, a Python-powered, cross-platform, Unix-gazing shell language.
 


### PR DESCRIPTION
Adding Helium MCP — a free REST + MCP API designed to be queried from inside Jupyter notebooks for financial and news research.

## What it provides

- **ML options pricing** — per-symbol predicted fair value, prob_ITM, Greeks
- **Structured news intelligence** — 3.2M+ articles, 31-dimension bias scoring (credibility, sensationalism, AI-authorship-probability, opinion-vs-fact, and 27 more)
- 10 REST endpoints, JSON in/out, 50 free queries per IP, no signup

## Why this section

Sits adjacent to [Quantopian Notebooks](https://www.quantopian.com/notebooks/survey) in spirit — a hosted/queryable analytical service designed to be consumed from notebooks, not a library you install. Useful for computational journalism, options research, and reproducible-narrative work in finance and media studies.

## One-line example for a notebook cell

\`\`\`python
import requests
r = requests.get(
    "https://heliumtrades.com/mcp_search/",
    params={"q": "apple earnings", "limit": 3},
)
r.json()  # 31-dim bias-scored articles, no auth needed
\`\`\`

Source: https://github.com/connerlambden/helium-mcp. Happy to relocate if there's a better section.

Made with [Cursor](https://cursor.com)