### PR TITLE
Add torchvista to Visualization section

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [Perspective](https://github.com/finos/perspective) - Data visualization and analytics component, especially for large/streaming datasets.
 - [pyecharts](https://github.com/pyecharts/pyecharts) - Python interface for the [ECharts](https://github.com/apache/incubator-echarts) visualization library.
 - [pythreejs](https://github.com/jovyan/pythreejs) - Python / ThreeJS bridge utilizing the Jupyter widget infrastructure.
+- [torchvista](https://github.com/sachinhosmani/torchvista) - Interactive tool to visualize the forward pass of a PyTorch model as a computation graph in notebooks, with collapsible nested modules, repeated-module compression and error-tolerant partial visualizations.
 - [tqdm](https://github.com/tqdm/tqdm) - Fast, extensible progress bar for loops and iterables.
 - [tributary](https://github.com/timkpaine/tributary) - Python data streams with Jupyter support.
 - [xleaflet](https://github.com/QuantStack/xleaflet) - C++ Backend for ipyleaflet.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [Perspective](https://github.com/finos/perspective) - Data visualization and analytics component, especially for large/streaming datasets.
 - [pyecharts](https://github.com/pyecharts/pyecharts) - Python interface for the [ECharts](https://github.com/apache/incubator-echarts) visualization library.
 - [pythreejs](https://github.com/jovyan/pythreejs) - Python / ThreeJS bridge utilizing the Jupyter widget infrastructure.
-- [torchvista](https://github.com/sachinhosmani/torchvista) - Interactive tool to visualize the forward pass of a PyTorch model as a computation graph in notebooks, with collapsible nested modules, repeated-module compression and error-tolerant partial visualizations.
+- [torchvista](https://github.com/sachinhosmani/torchvista) - Interactive tool to visualize the forward pass of PyTorch models as a graph in notebooks.
 - [tqdm](https://github.com/tqdm/tqdm) - Fast, extensible progress bar for loops and iterables.
 - [tributary](https://github.com/timkpaine/tributary) - Python data streams with Jupyter support.
 - [xleaflet](https://github.com/QuantStack/xleaflet) - C++ Backend for ipyleaflet.


### PR DESCRIPTION
Torchvista is an interactive tool to visualise the forward pass of a PyTorch model as a computation graph, directly within notebooks (Jupyter, Colab, etc.) in a single line of code. It supports collapsible nested modules for exploring complex architectures and produces error-resilient partial visualisations to aid debugging (e.g. shape mismatches).

### Contribution checklist
- [x] Has ≥500 GitHub stars (currently ~743)
- [x] Actively maintained (last commit within the last 12 months (and has had good community participation)
