### PR TITLE
feat: add TWZRD Agent Intel MCP server to Domain-Specific Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [lolviz](https://github.com/parrt/lolviz) - Data-structure visualization tool for lists of lists, lists, dictionaries.
 - [Quantopian Notebooks](https://www.quantopian.com/notebooks/survey) - Jupyter-based platform for financial research.
 - [vpython-jupyter](https://github.com/BruceSherwood/vpython-jupyter) - VPython 3D engine running in a Jupyter notebook.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - MCP server providing trust scoring for AI agent wallets; use the `score_agent(wallet)` and `preflight_check(wallet)` tools from Jupyter notebooks to verify autonomous agents before authorising payments or sensitive actions.
 - [xontrib-jupyter](https://github.com/xonsh/xontrib-jupyter) - Jupyter kernel for xonsh, a Python-powered, cross-platform, Unix-gazing shell language.
 
 ## Hosted Notebook Solutions


### PR DESCRIPTION
## What

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Domain-Specific Projects** section — an MCP (Model Context Protocol) server that exposes trust-scoring tools for AI agent wallets. Data scientists and AI engineers can call `score_agent(wallet)` or `preflight_check(wallet)` directly from Jupyter notebooks to verify autonomous agents before authorising payments or sensitive actions.

## Why it belongs here

The list already includes [jupyter-ai](https://github.com/jupyterlab/jupyter-ai) under JupyterLab Extensions. TWZRD Agent Intel extends that ecosystem by bringing verifiable on-chain agent identity into the notebook workflow — a domain-specific concern for anyone building autonomous AI pipelines in Jupyter.

### Quick usage (Python kernel)

```python
import asyncio
from mcp import ClientSession
from mcp.client.streamable_http import streamablehttp_client

async def check_agent(wallet: str):
    async with streamablehttp_client("https://intel.twzrd.xyz/mcp") as (r, w, _):
        async with ClientSession(r, w) as s:
            await s.initialize()
            return await s.call_tool("score_agent", {"wallet": wallet})

asyncio.run(check_agent("D1QkbFJKiPsymJ65RKHhF6DFB8sPMfpBaFBzuHKfJGWi"))
```