### PR TITLE
Add FlexViz

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [Bokeh](https://bokeh.pydata.org/en/latest/) - Interactive visualization library that targets modern web browsers for presentation.
 - [bqplot](https://github.com/bloomberg/bqplot) - Grammar of Graphics-based interactive plotting framework for Jupyter.
 - [Evidently](https://github.com/evidentlyai/evidently) - Interactive reports to analyze machine learning models during validation or production monitoring.
+- [FlexViz](https://github.com/flex-analytics/flexviz) - Interactive cross-filter dashboards for datasets that are too large for the browser.
 - [hvplot](https://hvplot.holoviz.org/) - A familiar and high-level API for data exploration and visualization in Jupyter.
 - [ipychart](https://github.com/nicohlr/ipychart) - Interactive Chart.js plots in Jupyter.
 - [ipycytoscape](https://github.com/cytoscape/ipycytoscape) - Widget for interactive graph visualization in Jupyter using cytoscape.js. <!--lint disable double-link-->


### PR DESCRIPTION
Adds [FlexViz](https://github.com/flex-analytics/flexviz) to Visualization, in alphabetical position between Evidently and hvplot.

FlexViz is an Apache-2.0 Python library for interactive, cross-filtered dashboards over datasets that are too large to hand to the browser. `show()` renders inline in Jupyter / VS Code notebooks as an IFrame, and every zoom, pan, and brush is answered by a lazy [Polars](https://github.com/pola-rs/polars) aggregation plus Rust kernels on a stateless server, so only aggregated points cross the wire. Closest neighbour already on the list is Perspective, for the large/streaming-dataset use case.

- Docs: https://docs.flexviz.tech
- Live demo (2 x 100M rows, no signup): https://flexviz.tech/demo.html
- Benchmarks: https://flexviz.tech/benchmarks.html
- PyPI: https://pypi.org/project/flexviz/

`npx awesome-lint` reports no issue for this entry (the only local error, "Awesome list must reside in a valid git repository", also occurs on an unmodified checkout).

Disclosure: I am the author. Happy to adjust the wording.
