### PR TITLE
Add devscholar to JupyterLab Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ A curated list of awesome [Jupyter](http://jupyter.org) projects, libraries and 
 - [celltags](https://github.com/jupyterlab/jupyterlab-celltags) - Extension to organise and execute notebooks using cell tags.
 - [code_formatter](https://github.com/ryantam626/jupyterlab_code_formatter) - A universal code formatter.
 - [debugger](https://github.com/jupyterlab/debugger) - A visual debugger for Jupyter notebooks, consoles, and source files.
+- [devscholar](https://github.com/pallaprolus/devscholar-jupyter) - Hover metadata, PDF preview and BibTeX export for paper references (arXiv, DOI) in notebook cells.
 - [drawio](https://github.com/QuantStack/jupyterlab-drawio) - Extension that displays drawio/mxgraph diagrams.
 - [elyra](https://github.com/elyra-ai/elyra) - A visual editor for creating and running notebook (or Python script) pipelines locally or remotely.
 - [genv](https://github.com/run-ai/jupyterlab_genv) - Extension for managing GPU environments in JupyterLab.


### PR DESCRIPTION
Adds [devscholar](https://github.com/pallaprolus/devscholar-jupyter) to the JupyterLab Extensions section, in alphabetical position between debugger and drawio.

DevScholar for JupyterLab detects paper references (arXiv, DOI, IEEE, Semantic Scholar, OpenAlex) in markdown cells and code comments, underlines them, and shows title, authors, year, abstract and citation count on hover. It can preview the PDF inside JupyterLab, insert citations via a search dialog, export BibTeX, and sync with Zotero and Mendeley. Published on PyPI as `devscholar-jupyter`, MIT licensed, JupyterLab 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)